### PR TITLE
Incorporate payouts and move out-of-scope text

### DIFF
--- a/mozilla_core_services/bounties-bounty-table-description.md
+++ b/mozilla_core_services/bounties-bounty-table-description.md
@@ -1,7 +1,100 @@
-Our rewards are based on the severity of the issue and the criticality of the service or application. Definitions of the severity levels and examples can be found [here](https://www.mozilla.org/en-US/security/web-bug-bounty/). 
+Our rewards are based on the severity of the issue and the criticality of the service or application. 
+
+| Severity Rating | [Critical sites][1] | [Core sites][2] | Other Mozilla sites |
+|-----------------|---------------------|-----------------|---------------------|
+| Critical        | $6000 - $15000      | $3000 - $5000   | $500 - $1000        |
+| High            | $3000 - $6000       | $1000 - $3000   | 0 - $500            |
+| Moderate        | $1000 - $3000       | $500 - $1000    | \-                  |
+| Low             | 0 - $1000           | 0 - $500        | \-                  |
+
+Note : "Other Mozilla sites" excludes community websites
+
+# Severity Definitions and Examples
+
+## Critical
+
+Critical vulnerabilities are urgent security issues that present an ongoing or immediate danger to the users of our services and our infrastructure
+
+* Remote Code Execution
+* Authentication and Session Management Flaws (which lead to account compromise)
+* Disclosure of secrets in publicly accessible assets
+* Hardcoded credentials for a privileged user
+
+## High
+
+ Typically, high severity issues are exploitable web vulnerabilities that can lead to the targeted compromise of a small number of users.
+
+* Account takeover through Oauth misconfiguration
+* IDORs that bypass authentication or authorization for significant actions
+* CSRF on significant actions, such as changing email/passwords, deleting accounts, etc.
+* XSS resulting in conducting significant action (i.e., not defacement, phishing, cookie injection, etc.)
+* XML External Entity (XXE) attack
+* Hardcoded credentials for a non-privileged user
+
+## Moderate
+
+ Vulnerabilities which can provide an attacker additional information or positioning that could be used in combination with other vulnerabilities. In addition to issues resulting from the lack of standard defense in depth techniques and security controls.
+
+* XSS (minor)
+* Domain takeovers supported by a proof of concept for `*.mozilla.org`, `*.mozilla.com`, `*.mozilla.net`, and `*.firefox.com` in addition to the list of critical and core sites.
+* SSRF which leads to reaching **internal** network hosts
+* Disclosure of sensitive information which does not expose the user or organization to immediate risk
+* CSRF for minor actions.
+
+## Low
+
+ Minor security vulnerabilities which could lead to leaks or spoofs of non-sensitive information. Missing best practice security controls
+
+* XSS (blocked by CSP)
+* Clickjacking with demonstrated impact (Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty)
+* External SSRF
+* Open Redirects for `*.mozilla.org`, `*.mozilla.com`, `*.mozilla.net`, and `*.firefox.com` in addition to the list of critical and core sites.
+
+## Out of Scope
+
+Although we still appreciate being notified about them, the following issues fall outside the scope of our bug bounty program and are not eligible for bounty awards:
+
+* Self-XSS
+* Executing scripts on sandboxed domains (such as bmoattachments or mozillademos)
+* CSRF for non-significant actions (logout, forms with no sensitive actions, etc.)
+* Clickjacking attacks without a documented series of clicks that produce a vulnerability
+* Spam (including issues related to SPF/DKIM/DMARC)
+* Denial-of-service attacks or issues related to rate limiting
+* Attacks that require social engineering (phishing)
+* Content injection, such as reflected text or HTML tags
+* Missing HTTP headers, except as where their absence fails to mitigate an existing attack
+* Authentication bypasses that require access to software/hardware tokens
+* Vulnerabilities that only affect users with specific browsers (must work either in Firefox or Chrome)
+* Vulnerabilities that require access to passwords, tokens, or the local system (e.g. session fixation)
+* Assumed vulnerabilities based upon version numbers only
+* Source code disclosures, as most of our code is open source
+* Vulnerabilities discovered shortly after their public release
+* Outdated TLS configurations which remain to support downloads from Windows XP systems
+* **Blind** SSRF reports on services that are designed to load resources from the internet
+* Software version disclosure / Banner identification issues / Descriptive error messages or headers (e.g. stack traces, application or server errors).
+* Pocket MacOS application
+* Information disclosure vulnerabilities. Most Mozilla projects and code are open source and content on most sites is intentionally public.
+* Frequently reported issues which do not pose a security risk to users and aren't eligible for a bounty such as the ones tracked in [this tracker bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1830029).
+  * [Bugzilla user profile page discloses email address and lots of other info](https://bugzilla.mozilla.org/show_bug.cgi?id=1647545)
+  * [2FA Bypass on https://accounts.firefox.com/](https://bugzilla.mozilla.org/show_bug.cgi?id=1652071)
+  * [Verification token for 2FA authentication on accounts.firefox.com expires after 15 minutes not 5 minutes](https://bugzilla.mozilla.org/show_bug.cgi?id=1763878)
+  * [Ability to create more than two collections on developer.mozilla.org due to race condition](https://bugzilla.mozilla.org/show_bug.cgi?id=1818539)
+  * [Denial of Service using xmlrpc.php on Wordpress blogs like blog.mozilla.org](https://bugzilla.mozilla.org/show_bug.cgi?id=1050193)
+  * [blog.mozilla.com allows access to /wp-json and /wp-admin](https://bugzilla.mozilla.org/show_bug.cgi?id=1365661)
+  * [https://hubs.mozilla.com/api endpoint is publicly accessible](https://bugzilla.mozilla.org/show_bug.cgi?id=1748142)
+  * [https://hg.mozilla.org/users/ shows the contents of user directories](https://bugzilla.mozilla.org/show_bug.cgi?id=1767024)
+  * [contile.services.mozilla.com or other backend services have permissive CORS configurations](https://bugzilla.mozilla.org/show_bug.cgi?id=1782395)
+  * [The site https://ftp.mozilla.org/pub/](https://bugzilla.mozilla.org/show_bug.cgi?id=1783721) and [the site https://archive.mozilla.org/pub/](https://bugzilla.mozilla.org/show_bug.cgi?id=1810203) allow directory listing
+  * [Link from accounts.firefox.com to manage email preferences is missing authentication](https://bugzilla.mozilla.org/show_bug.cgi?id=1794310)
+  * [Blind SSRF using the pocket save URL feature](https://bugzilla.mozilla.org/show_bug.cgi?id=1810997)
+  * [https://people.mozilla.org/whoami/github/username/68190427 exposes user's GitHub profile information](https://bugzilla.mozilla.org/show_bug.cgi?id=1811757)
+  * [The sites https://community-tc.services.mozilla.com/ and https://firefox-ci-tc.services.mozilla.com/](https://bugzilla.mozilla.org/show_bug.cgi?id=1819389) as well as [the site https://normandy-devtools.services.mozilla.com/] are publicly accessible
 
 We have a bug bounty panel whose members decide whether a report is eligible for bounty and the bounty amount for eligible reports. The panel meets on a weekly basis, except for holidays and vacations, to discuss bounty decisions.
 
 Note that some low severity issues are not eligible for monetary awards based on their impact. We will recognize the reporter by thanking them on our H1 page.
 
 Please note these are general guidelines, and reward decisions are up to the discretion of Mozilla.
+
+[1]: https://hackerone.com/mozilla_critical_services/
+[2]: https://hackerone.com/mozilla_core_services

--- a/mozilla_core_services/policy.md
+++ b/mozilla_core_services/policy.md
@@ -2,7 +2,7 @@ The Mozilla Bug Bounty Program is designed to encourage security research into M
 
 # Program Scope
 
-Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless you think the bug is critical (see above for examples of critical issues)
+Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless the bug is critical (see above for examples of critical issues)
 
 # Test Plan
 

--- a/mozilla_core_services/policy.md
+++ b/mozilla_core_services/policy.md
@@ -2,23 +2,25 @@ The Mozilla Bug Bounty Program is designed to encourage security research into M
 
 # Program Scope
 
-Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless you think the bug is critical. Please check our [website](https://www.mozilla.org/en-US/security/web-bug-bounty/) for examples of what we consider critical issues.
+Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless you think the bug is critical (see above for examples of critical issues)
 
 # Test Plan
+
 * Whenever it is explicitly stated in our program scope, you are expected to test on the provided instances (e.g. staging) instead of production.
 * We ask that hackers test the application on the staging environment instead of the production environment. This will help ensure that any potential vulnerabilities are identified and addressed before they can be exploited in the production environment. Additionally, testing on the staging environment will help minimize any potential disruption to the production environment.
 
 # Program Rules
+
 Please provide detailed reports with reproducible steps. If the report is not detailed enough to reproduce the issue, the issue will not be eligible for a reward.
 
 To be eligible for a reward under this program:
 
 * The security bug must be original and previously unreported. 
-* The security bug must be a part of Mozilla’s code, not the code of a third party. We will pay bounties for vulnerabilities in third-party libraries incorporated into shipped client code or third-party websites utilized by Mozilla.
+* The security bug must be a part of Mozilla's code, not the code of a third party. We will pay bounties for vulnerabilities in third-party libraries incorporated into shipped client code or third-party websites utilized by Mozilla.
 * You must not have written the buggy code or otherwise been involved in contributing the buggy code to the Mozilla project.
 * You must be old enough to be eligible to participate in and receive payment from this program in your jurisdiction, or otherwise qualify to receive payment, whether through consent from your parent or guardian or some other way.
- * You must not be an employee, contractor, or otherwise have a business relationship with the Mozilla Foundation or any of its subsidiaries.
-* You should use your best effort not to access, modify, delete, or store user data or Mozilla’s data. Instead, use your own accounts or test accounts for security research purposes.
+* You must not be an employee, contractor, or otherwise have a business relationship with the Mozilla Foundation or any of its subsidiaries.
+* You should use your best effort not to access, modify, delete, or store user data or Mozilla's data. Instead, use your own accounts or test accounts for security research purposes.
 * If you inadvertently access, modify, delete, or store user data, we ask that you notify Mozilla immediately at security@mozilla.org and delete any stored data after notifying us.
 * You should also use your best effort not to harm the availability or stability of our services, for example, by running aggressive scanning of those services. Instead, use a local development instance of the service that you want to test.
 * Whenever it is explicitly stated in our program scope, you are expected to test on the provided instances (e.g. staging) instead of production.
@@ -27,10 +29,11 @@ To be eligible for a reward under this program:
 * Before sharing any part of the security issue with a third party, you must give us a reasonable amount of time to address the security issue.
 * All submissions will be covered under [Mozilla's Website & Communications Terms of Use](https://www.mozilla.org/en-US/about/legal/terms/mozilla/), granting us permission to make use of all submissions.
 * All submissions must also abide by [HackerOne Code of Conduct](https://www.hackerone.com/policies/code-of-conduct) and [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
-* Bounties can be donated to charity, please follow the [HackerOne process](https://docs.hackerone.com/hackers/payments.html#donating-bounties-to-charity) if you would like to donate your bounty money.
+* Bounties can be donated to charity. Please follow the [HackerOne process](https://docs.hackerone.com/hackers/payments.html#donating-bounties-to-charity) if you would like to donate your bounty money.
 * Do not threaten or attempt to extort Mozilla. We will not award a bounty if you threaten to withhold the security issue from us or if you threaten to release the vulnerability or any exposed data to the public.
 
 # Response Targets
+
 Mozilla will make a best effort to meet the following SLAs for hackers participating in our program:
 
 | Type of Response | SLA in business days |
@@ -40,38 +43,13 @@ Mozilla will make a best effort to meet the following SLAs for hackers participa
 | Time to Bounty | 30 days |
 | Time to Resolution | depends on severity and complexity |
 
-We’ll try to keep you informed about our progress throughout the process.
+We'll try to keep you informed about our progress throughout the process.
 
 # Disclosure Policy
+
 * Our program discloses security reports when they are fixed and rewarded. We make exceptions in case reporters have a valid reason for not using full disclosure or when they need more time in the research before the report is disclosed. We can consider partial disclosure in those cases, we can discuss and agree on the type of disclosure.
 * Follow HackerOne's [disclosure guidelines](https://www.hackerone.com/disclosure-guidelines).
 
-# Out of scope vulnerabilities
-
-### Although we still appreciate being notified about them, the following issues fall outside the scope of our bug bounty program:
-
-* Self-XSS
-* Executing scripts on sandboxed domains (such as bmoattachments or mozillademos)
-* CSRF for non-significant actions (logout, forms with no sensitive actions, etc.)
-* Clickjacking attacks without a documented series of clicks that produce a vulnerability
-* Spam (including issues related to SPF/DKIM/DMARC)
-* Denial-of-service attacks or issues related to rate limiting
-* Attacks that require social engineering (phishing)
-* Content injection, such as reflected text or HTML tags
-* Missing HTTP headers, except as where their absence fails to mitigate an existing attack
-* Authentication bypasses that require access to software/hardware tokens
-* Vulnerabilities that only affect users with specific browsers (must work either in Firefox or Chrome)
-* Vulnerabilities that require access to passwords, tokens, or the local system (e.g. session fixation)
-* Assumed vulnerabilities based upon version numbers only
-* Source code disclosures, as most of our code is open source
-* Vulnerabilities discovered shortly after their public release
-* Outdated TLS configurations which remain to support downloads from Windows XP systems
-* Blind SSRF reports on services that are designed to load resources from the internet
-* Software version disclosure / Banner identification issues / Descriptive error messages or headers (e.g. stack traces, application or server errors).
-* Pocket MacOS application
-* Information disclosure vulnerabilities. Most Mozilla projects and code are open source and content on most sites is intentionally public.
-* Check the list of bugs included in [this tracker bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1830029) for frequently reported issues which do not pose a security risk to users.
-    
 # Safe Harbor
 
 Mozilla strongly supports security research into our products and wants to encourage that research.
@@ -83,6 +61,6 @@ As long as you comply with this policy:
  * We consider your security research to be "authorized" under the Computer Fraud and Abuse Act,
  * We waive any restrictions in our applicable Terms of Service and [Acceptable Use Policy]( https://www.mozilla.org/en-US/about/legal/acceptable-use/) that would prohibit your participation in this policy, for the limited purpose of your security research under this policy.
 
-We understand that many Mozilla systems and services are interconnected with third-party systems and services. While we can authorize your research on Mozilla’s systems and services, and promise that Mozilla will not bring or threaten litigation against you for your efforts under this policy, we cannot authorize efforts on third-party products or guarantee they won’t pursue legal action against you. However, if a third party threatens or brings any legal action against you for your efforts under this policy, we are willing to make clear—to the Court, the public, or otherwise--that we authorized your efforts to test and research the security of Mozilla’s eligible systems and services.
+We understand that many Mozilla systems and services are interconnected with third-party systems and services. While we can authorize your research on Mozilla's systems and services, and promise that Mozilla will not bring or threaten litigation against you for your efforts under this policy, we cannot authorize efforts on third-party products or guarantee they won't pursue legal action against you. However, if a third party threatens or brings any legal action against you for your efforts under this policy, we are willing to make clear to the Court, the public, or otherwise that we authorized your efforts to test and research the security of Mozilla's eligible systems and services.
 
-If you’re not sure whether your conduct complies with this policy, please contact us first at security@mozilla.org and we will do our best to clarify.
+If you're not sure whether your conduct complies with this policy, please contact us first at security@mozilla.org and we will do our best to clarify.

--- a/mozilla_critical_services/bounties-bounty-table-description.md
+++ b/mozilla_critical_services/bounties-bounty-table-description.md
@@ -1,7 +1,100 @@
-Our rewards are based on the severity of the issue and the criticality of the service or application. Definitions of the severity levels and examples can be found [here](https://www.mozilla.org/en-US/security/web-bug-bounty/). 
+Our rewards are based on the severity of the issue and the criticality of the service or application. 
+
+| Severity Rating | [Critical sites][1] | [Core sites][2] | Other Mozilla sites |
+|-----------------|---------------------|-----------------|---------------------|
+| Critical        | $6000 - $15000      | $3000 - $5000   | $500 - $1000        |
+| High            | $3000 - $6000       | $1000 - $3000   | 0 - $500            |
+| Moderate        | $1000 - $3000       | $500 - $1000    | \-                  |
+| Low             | 0 - $1000           | 0 - $500        | \-                  |
+
+Note : "Other Mozilla sites" excludes community websites
+
+# Severity Definitions and Examples
+
+## Critical
+
+Critical vulnerabilities are urgent security issues that present an ongoing or immediate danger to the users of our services and our infrastructure
+
+* Remote Code Execution
+* Authentication and Session Management Flaws (which lead to account compromise)
+* Disclosure of secrets in publicly accessible assets
+* Hardcoded credentials for a privileged user
+
+## High
+
+ Typically, high severity issues are exploitable web vulnerabilities that can lead to the targeted compromise of a small number of users.
+
+* Account takeover through Oauth misconfiguration
+* IDORs that bypass authentication or authorization for significant actions
+* CSRF on significant actions, such as changing email/passwords, deleting accounts, etc.
+* XSS resulting in conducting significant action (i.e., not defacement, phishing, cookie injection, etc.)
+* XML External Entity (XXE) attack
+* Hardcoded credentials for a non-privileged user
+
+## Moderate
+
+ Vulnerabilities which can provide an attacker additional information or positioning that could be used in combination with other vulnerabilities. In addition to issues resulting from the lack of standard defense in depth techniques and security controls.
+
+* XSS (minor)
+* Domain takeovers supported by a proof of concept for `*.mozilla.org`, `*.mozilla.com`, `*.mozilla.net`, and `*.firefox.com` in addition to the list of critical and core sites.
+* SSRF which leads to reaching **internal** network hosts
+* Disclosure of sensitive information which does not expose the user or organization to immediate risk
+* CSRF for minor actions.
+
+## Low
+
+ Minor security vulnerabilities which could lead to leaks or spoofs of non-sensitive information. Missing best practice security controls
+
+* XSS (blocked by CSP)
+* Clickjacking with demonstrated impact (Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty)
+* External SSRF
+* Open Redirects for `*.mozilla.org`, `*.mozilla.com`, `*.mozilla.net`, and `*.firefox.com` in addition to the list of critical and core sites.
+
+## Out of Scope
+
+Although we still appreciate being notified about them, the following issues fall outside the scope of our bug bounty program and are not eligible for bounty awards:
+
+* Self-XSS
+* Executing scripts on sandboxed domains (such as bmoattachments or mozillademos)
+* CSRF for non-significant actions (logout, forms with no sensitive actions, etc.)
+* Clickjacking attacks without a documented series of clicks that produce a vulnerability
+* Spam (including issues related to SPF/DKIM/DMARC)
+* Denial-of-service attacks or issues related to rate limiting
+* Attacks that require social engineering (phishing)
+* Content injection, such as reflected text or HTML tags
+* Missing HTTP headers, except as where their absence fails to mitigate an existing attack
+* Authentication bypasses that require access to software/hardware tokens
+* Vulnerabilities that only affect users with specific browsers (must work either in Firefox or Chrome)
+* Vulnerabilities that require access to passwords, tokens, or the local system (e.g. session fixation)
+* Assumed vulnerabilities based upon version numbers only
+* Source code disclosures, as most of our code is open source
+* Vulnerabilities discovered shortly after their public release
+* Outdated TLS configurations which remain to support downloads from Windows XP systems
+* **Blind** SSRF reports on services that are designed to load resources from the internet
+* Software version disclosure / Banner identification issues / Descriptive error messages or headers (e.g. stack traces, application or server errors).
+* Pocket MacOS application
+* Information disclosure vulnerabilities. Most Mozilla projects and code are open source and content on most sites is intentionally public.
+* Frequently reported issues which do not pose a security risk to users and aren't eligible for a bounty such as the ones tracked in [this tracker bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1830029).
+  * [Bugzilla user profile page discloses email address and lots of other info](https://bugzilla.mozilla.org/show_bug.cgi?id=1647545)
+  * [2FA Bypass on https://accounts.firefox.com/](https://bugzilla.mozilla.org/show_bug.cgi?id=1652071)
+  * [Verification token for 2FA authentication on accounts.firefox.com expires after 15 minutes not 5 minutes](https://bugzilla.mozilla.org/show_bug.cgi?id=1763878)
+  * [Ability to create more than two collections on developer.mozilla.org due to race condition](https://bugzilla.mozilla.org/show_bug.cgi?id=1818539)
+  * [Denial of Service using xmlrpc.php on Wordpress blogs like blog.mozilla.org](https://bugzilla.mozilla.org/show_bug.cgi?id=1050193)
+  * [blog.mozilla.com allows access to /wp-json and /wp-admin](https://bugzilla.mozilla.org/show_bug.cgi?id=1365661)
+  * [https://hubs.mozilla.com/api endpoint is publicly accessible](https://bugzilla.mozilla.org/show_bug.cgi?id=1748142)
+  * [https://hg.mozilla.org/users/ shows the contents of user directories](https://bugzilla.mozilla.org/show_bug.cgi?id=1767024)
+  * [contile.services.mozilla.com or other backend services have permissive CORS configurations](https://bugzilla.mozilla.org/show_bug.cgi?id=1782395)
+  * [The site https://ftp.mozilla.org/pub/](https://bugzilla.mozilla.org/show_bug.cgi?id=1783721) and [the site https://archive.mozilla.org/pub/](https://bugzilla.mozilla.org/show_bug.cgi?id=1810203) allow directory listing
+  * [Link from accounts.firefox.com to manage email preferences is missing authentication](https://bugzilla.mozilla.org/show_bug.cgi?id=1794310)
+  * [Blind SSRF using the pocket save URL feature](https://bugzilla.mozilla.org/show_bug.cgi?id=1810997)
+  * [https://people.mozilla.org/whoami/github/username/68190427 exposes user's GitHub profile information](https://bugzilla.mozilla.org/show_bug.cgi?id=1811757)
+  * [The sites https://community-tc.services.mozilla.com/ and https://firefox-ci-tc.services.mozilla.com/](https://bugzilla.mozilla.org/show_bug.cgi?id=1819389) as well as [the site https://normandy-devtools.services.mozilla.com/] are publicly accessible
 
 We have a bug bounty panel whose members decide whether a report is eligible for bounty and the bounty amount for eligible reports. The panel meets on a weekly basis, except for holidays and vacations, to discuss bounty decisions.
 
 Note that some low severity issues are not eligible for monetary awards based on their impact. We will recognize the reporter by thanking them on our H1 page.
 
 Please note these are general guidelines, and reward decisions are up to the discretion of Mozilla.
+
+[1]: https://hackerone.com/mozilla_critical_services/
+[2]: https://hackerone.com/mozilla_core_services

--- a/mozilla_critical_services/policy.md
+++ b/mozilla_critical_services/policy.md
@@ -2,7 +2,7 @@ The Mozilla Bug Bounty Program is designed to encourage security research into M
 
 # Program Scope
 
-Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless you think the bug is critical (see above for examples of critical issues)
+Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless the bug is critical (see above for examples of critical issues)
 
 # Test Plan
 

--- a/mozilla_critical_services/policy.md
+++ b/mozilla_critical_services/policy.md
@@ -2,23 +2,25 @@ The Mozilla Bug Bounty Program is designed to encourage security research into M
 
 # Program Scope
 
-Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless you think the bug is critical. Please check our [website](https://www.mozilla.org/en-US/security/web-bug-bounty/) for examples of what we consider critical issues.
+Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless you think the bug is critical (see above for examples of critical issues)
 
 # Test Plan
+
 * Whenever it is explicitly stated in our program scope, you are expected to test on the provided instances (e.g. staging) instead of production.
 * We ask that hackers test the application on the staging environment instead of the production environment. This will help ensure that any potential vulnerabilities are identified and addressed before they can be exploited in the production environment. Additionally, testing on the staging environment will help minimize any potential disruption to the production environment.
 
 # Program Rules
+
 Please provide detailed reports with reproducible steps. If the report is not detailed enough to reproduce the issue, the issue will not be eligible for a reward.
 
 To be eligible for a reward under this program:
 
-* The security bug must be original and previously unreported.
-* The security bug must be a part of Mozilla’s code, not the code of a third party. We will pay bounties for vulnerabilities in third-party libraries incorporated into shipped client code or third-party websites utilized by Mozilla.
+* The security bug must be original and previously unreported. 
+* The security bug must be a part of Mozilla's code, not the code of a third party. We will pay bounties for vulnerabilities in third-party libraries incorporated into shipped client code or third-party websites utilized by Mozilla.
 * You must not have written the buggy code or otherwise been involved in contributing the buggy code to the Mozilla project.
 * You must be old enough to be eligible to participate in and receive payment from this program in your jurisdiction, or otherwise qualify to receive payment, whether through consent from your parent or guardian or some other way.
- * You must not be an employee, contractor, or otherwise have a business relationship with the Mozilla Foundation or any of its subsidiaries.
-* You should use your best effort not to access, modify, delete, or store user data or Mozilla’s data. Instead, use your own accounts or test accounts for security research purposes.
+* You must not be an employee, contractor, or otherwise have a business relationship with the Mozilla Foundation or any of its subsidiaries.
+* You should use your best effort not to access, modify, delete, or store user data or Mozilla's data. Instead, use your own accounts or test accounts for security research purposes.
 * If you inadvertently access, modify, delete, or store user data, we ask that you notify Mozilla immediately at security@mozilla.org and delete any stored data after notifying us.
 * You should also use your best effort not to harm the availability or stability of our services, for example, by running aggressive scanning of those services. Instead, use a local development instance of the service that you want to test.
 * Whenever it is explicitly stated in our program scope, you are expected to test on the provided instances (e.g. staging) instead of production.
@@ -27,10 +29,11 @@ To be eligible for a reward under this program:
 * Before sharing any part of the security issue with a third party, you must give us a reasonable amount of time to address the security issue.
 * All submissions will be covered under [Mozilla's Website & Communications Terms of Use](https://www.mozilla.org/en-US/about/legal/terms/mozilla/), granting us permission to make use of all submissions.
 * All submissions must also abide by [HackerOne Code of Conduct](https://www.hackerone.com/policies/code-of-conduct) and [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
-* Bounties can be donated to charity, please follow the [HackerOne process](https://docs.hackerone.com/hackers/payments.html#donating-bounties-to-charity) if you would like to donate your bounty money.
+* Bounties can be donated to charity. Please follow the [HackerOne process](https://docs.hackerone.com/hackers/payments.html#donating-bounties-to-charity) if you would like to donate your bounty money.
 * Do not threaten or attempt to extort Mozilla. We will not award a bounty if you threaten to withhold the security issue from us or if you threaten to release the vulnerability or any exposed data to the public.
 
 # Response Targets
+
 Mozilla will make a best effort to meet the following SLAs for hackers participating in our program:
 
 | Type of Response | SLA in business days |
@@ -40,37 +43,13 @@ Mozilla will make a best effort to meet the following SLAs for hackers participa
 | Time to Bounty | 30 days |
 | Time to Resolution | depends on severity and complexity |
 
-We’ll try to keep you informed about our progress throughout the process.
+We'll try to keep you informed about our progress throughout the process.
 
 # Disclosure Policy
+
 * Our program discloses security reports when they are fixed and rewarded. We make exceptions in case reporters have a valid reason for not using full disclosure or when they need more time in the research before the report is disclosed. We can consider partial disclosure in those cases, we can discuss and agree on the type of disclosure.
 * Follow HackerOne's [disclosure guidelines](https://www.hackerone.com/disclosure-guidelines).
 
-# Out of scope vulnerabilities
-
-### Although we still appreciate being notified about them, the following issues fall outside the scope of our bug bounty program:
-
-* Self-XSS
-* Executing scripts on sandboxed domains (such as bmoattachments or mozillademos)
-* CSRF for non-significant actions (logout, forms with no sensitive actions, etc.)
-* Clickjacking attacks without a documented series of clicks that produce a vulnerability
-* Spam (including issues related to SPF/DKIM/DMARC)
-* Denial-of-service attacks or issues related to rate limiting
-* Attacks that require social engineering (phishing)
-* Content injection, such as reflected text or HTML tags
-* Missing HTTP headers, except as where their absence fails to mitigate an existing attack
-* Authentication bypasses that require access to software/hardware tokens
-* Vulnerabilities that only affect users with specific browsers (must work either in Firefox or Chrome)
-* Vulnerabilities that require access to passwords, tokens, or the local system (e.g. session fixation)
-* Assumed vulnerabilities based upon version numbers only
-* Source code disclosures, as most of our code is open source
-* Vulnerabilities discovered shortly after their public release
-* Outdated TLS configurations which remain to support downloads from Windows XP systems
-* Blind SSRF reports on services that are designed to load resources from the internet
-* Software version disclosure / Banner identification issues / Descriptive error messages or headers (e.g. stack traces, application or server errors).
-* Information disclosure vulnerabilities. Most Mozilla projects and code are open source and content on most sites is intentionally public.
-* Check the list of bugs included in [this tracker bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1830029) for frequently reported issues which do not pose a security risk to users.
-    
 # Safe Harbor
 
 Mozilla strongly supports security research into our products and wants to encourage that research.
@@ -82,6 +61,6 @@ As long as you comply with this policy:
  * We consider your security research to be "authorized" under the Computer Fraud and Abuse Act,
  * We waive any restrictions in our applicable Terms of Service and [Acceptable Use Policy]( https://www.mozilla.org/en-US/about/legal/acceptable-use/) that would prohibit your participation in this policy, for the limited purpose of your security research under this policy.
 
-We understand that many Mozilla systems and services are interconnected with third-party systems and services. While we can authorize your research on Mozilla’s systems and services, and promise that Mozilla will not bring or threaten litigation against you for your efforts under this policy, we cannot authorize efforts on third-party products or guarantee they won’t pursue legal action against you. However, if a third party threatens or brings any legal action against you for your efforts under this policy, we are willing to make clear—to the Court, the public, or otherwise--that we authorized your efforts to test and research the security of Mozilla’s eligible systems and services.
+We understand that many Mozilla systems and services are interconnected with third-party systems and services. While we can authorize your research on Mozilla's systems and services, and promise that Mozilla will not bring or threaten litigation against you for your efforts under this policy, we cannot authorize efforts on third-party products or guarantee they won't pursue legal action against you. However, if a third party threatens or brings any legal action against you for your efforts under this policy, we are willing to make clear to the Court, the public, or otherwise that we authorized your efforts to test and research the security of Mozilla's eligible systems and services.
 
-If you’re not sure whether your conduct complies with this policy, please contact us first at security@mozilla.org and we will do our best to clarify.
+If you're not sure whether your conduct complies with this policy, please contact us first at security@mozilla.org and we will do our best to clarify.


### PR DESCRIPTION
This adds in the payouts details, examples of each severity and severity descriptions. It also moves the listed out-of-scope details from the policy page to the bounty page.