### PR TITLE
Expand the reference to critical bugs to include examples

### DIFF
--- a/mozilla_critical_services/scope-description.md
+++ b/mozilla_critical_services/scope-description.md
@@ -1,1 +1,6 @@
-Below are the sites that are considered in scope of the program, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless the bug is critical. Please check the policy page for examples of what we consider critical issues.
+Below are the sites that are considered in scope of the program, we would
+like testing to focus on those sites. Other sites and services are considered
+out of scope of the program unless the bug is critical. Critical bugs include
+issues involving remote code execution, authentication and session management
+flaws (which lead to account compromise), disclosure of secrets in publicly
+accessible assets as well as hardcoded credentials for a privileged user.


### PR DESCRIPTION
Previously the scope description referenced another page with examples of critical bugs. This adds those examples directly into the scope description for greater clarity.