### PR TITLE
use industry defaults for response targets

### DIFF
--- a/mozilla_critical_services/policy.md
+++ b/mozilla_critical_services/policy.md
@@ -38,8 +38,8 @@ Mozilla will make a best effort to meet the following SLAs for hackers participa
 
 | Type of Response | SLA in business days |
 | ------------- | ------------- |
-| First Response | 2 days |
-| Time to Triage | 2 days |
+| First Response | 5 days |
+| Time to Triage | 10 days |
 | Time to Bounty | 30 days |
 | Time to Resolution | depends on severity and complexity |
 


### PR DESCRIPTION
I already changed the response times in our policy before going to the all hands and I propose we keep the recommended response times by H1.