### PR TITLE
Remove Safe Harbor Notice

### DIFF
--- a/mozilla_critical_services/policy.md
+++ b/mozilla_critical_services/policy.md
@@ -7,7 +7,7 @@ The Mozilla Bug Bounty Program is designed to encourage security research into M
 4. Appeal Process
 5. Response Targets
 6. Disclosure Policy
-7. Safe Harbor
+
 # Program Scope
 
 Please check the list of sites under the Scope section, we would like testing to focus on those sites. Other sites and services are considered out of scope of the program unless the bug is critical (see above for examples of critical issues)
@@ -64,18 +64,3 @@ We'll try to keep you informed about our progress throughout the process.
 
 * Our program discloses security reports when they are fixed and rewarded. We make exceptions in case reporters have a valid reason for not using full disclosure or when they need more time in the research before the report is disclosed. We can consider partial disclosure in those cases, we can discuss and agree on the type of disclosure.
 * Follow HackerOne's [disclosure guidelines](https://www.hackerone.com/disclosure-guidelines).
-
-# Safe Harbor
-
-Mozilla strongly supports security research into our products and wants to encourage that research.
-
-As a result, we will not threaten or bring any legal action against anyone who makes a good faith effort to comply with this Bug Bounty Program, or for any accidental or good faith violation of this policy. This includes any claim under the DMCA for circumventing technological measures to protect the services and applications eligible under this policy.
-
-As long as you comply with this policy:
-
- * We consider your security research to be "authorized" under the Computer Fraud and Abuse Act,
- * We waive any restrictions in our applicable Terms of Service and [Acceptable Use Policy]( https://www.mozilla.org/en-US/about/legal/acceptable-use/) that would prohibit your participation in this policy, for the limited purpose of your security research under this policy.
-
-We understand that many Mozilla systems and services are interconnected with third-party systems and services. While we can authorize your research on Mozilla's systems and services, and promise that Mozilla will not bring or threaten litigation against you for your efforts under this policy, we cannot authorize efforts on third-party products or guarantee they won't pursue legal action against you. However, if a third party threatens or brings any legal action against you for your efforts under this policy, we are willing to make clear to the Court, the public, or otherwise that we authorized your efforts to test and research the security of Mozilla's eligible systems and services.
-
-If you're not sure whether your conduct complies with this policy, please contact us first at security@mozilla.org and we will do our best to clarify.


### PR DESCRIPTION
Remove Mozilla's Safe Harbor notice to not conflict with H1's Safe Harbor notice.