### PR TITLE
Document where introduction.md goes

### DIFF
--- a/mozilla/README.md
+++ b/mozilla/README.md
@@ -3,3 +3,4 @@
 * [`submit-report-form-introduction.md`](submit-report-form-introduction.md) : https://hackerone.com/mozilla/submission_form
 * [`submit-report-form-report-template.md`](submit-report-form-report-template.md) : https://hackerone.com/mozilla/submission_form
 * [`submit-report-form-impact-template.md`](submit-report-form-impact-template.md) : https://hackerone.com/mozilla/submission_form
+* [`introduction.md`](introduction.md) : https://hackerone.com/mozilla/policy (In the `Overview`... `Introduction` field)

--- a/mozilla/introduction.md
+++ b/mozilla/introduction.md
@@ -1,2 +1,1 @@
-<!-- Introduction is added under Program Overview -> Introduction in https://hackerone.com/mozilla/edit -->
 The Mozilla Bug Bounty Program is designed to encourage security research into Mozilla's websites and services and to reward those who find unique and original security bugs in our web infrastructure. We appreciate your interest and effort in improving the security of our applications, and look forward to collaborating with you.


### PR DESCRIPTION
This removes the HTML comment which had outdated information from `introduction.md` and adds a section to the `mozilla/README.md` file explaining where the `introduction.md` content goes in the Hackerone UI

Fixes #21