### PR TITLE
Change name of Moderate severity to Medium

### DIFF
--- a/mozilla/policy.md
+++ b/mozilla/policy.md
@@ -38,7 +38,7 @@ Critical vulnerabilities are urgent security issues that present an ongoing or i
 * XML External Entity (XXE) attack
 * Hardcoded credentials for a non-privileged user
 
-## Moderate
+## Medium
 
  Vulnerabilities which can provide an attacker additional information or positioning that could be used in combination with other vulnerabilities. In addition to issues resulting from the lack of standard defense in depth techniques and security controls.
 


### PR DESCRIPTION
The policy had the wrong name for one of the severities. It didn't match the Hackerone severity of "Medium" this changes the policy to match Hackerone.